### PR TITLE
accomodate tidy format with multiple blanks

### DIFF
--- a/R/data_parsers.R
+++ b/R/data_parsers.R
@@ -728,6 +728,16 @@ tidy_to_custom <- function(df, data.format = "col"){
         concentration <- subset[subset$Group == group,]$Concentration[1]
         values <- subset[subset$Group == group,]$Values
 
+        nreps <- round(length(values)/(nrow(new_df)-3))
+        
+        for (i in 1:nreps) {
+          start_index <- 1 + ((nrow(new_df) - 3) * (i - 1))
+          end_index <- (nrow(new_df) - 3) * i
+          
+          column_name <- paste0(group, "_", i)
+          new_df[, column_name] <- c(description, replicate, concentration, values[start_index:end_index])
+        }
+        
         # create a new column for the Group
         new_df[, group] <- c(description, replicate, concentration, values)
       }

--- a/R/data_parsers.R
+++ b/R/data_parsers.R
@@ -717,7 +717,7 @@ tidy_to_custom <- function(df, data.format = "col"){
       # for each unique Group, create a column in the new dataframe
       for (group in unique_groups) {
         # get the corresponding Description, Replicate, Concentration, and Values
-        description <- subset[subset$Group == group,]$Description[1]
+        description <- as.character(subset[subset$Group == group,]$Description[1])
         replicate <- subset[subset$Group == group,]$Replicate[1]
         concentration <- subset[subset$Group == group,]$Concentration[1]
         values <- subset[subset$Group == group,]$Values

--- a/R/data_parsers.R
+++ b/R/data_parsers.R
@@ -458,10 +458,16 @@ read_data <-
     if(((length(fl) > 1 ) || !is.na(data.fl)) && length(dat)>1){fl.norm.mat <- create_datmat(df=fl.norm, time.ndx=time.ndx);  fl.norm.mat[,1] <- gsub("\\n\\r|\\n|\\r", "", fl.norm.mat[,1])}else{fl.norm.mat <- NA}
     # if(((length(fl2) > 1 ) || !is.na(data.fl2)) && length(dat)>1){fl2.norm.mat <- create_datmat(df=fl2.norm, time.ndx=time.ndx);  fl2.norm.mat[,1] <- gsub("\\n\\r|\\n|\\r", "", fl2.norm.mat[,1])}else{fl2.norm.mat <- NA}
 
-    if(length(dat)>1)             colnames(dat.mat)[1:3] <- c("condition", "replicate", "concentration")
-    if((length(fl) > 1 ) || !is.na(data.fl))    colnames(fl.mat)[1:3] <- c("condition", "replicate", "concentration")
+    if(length(dat)>1)             
+      colnames(dat.mat) <- rep("", ncol(dat.mat))
+      colnames(dat.mat)[1:3] <- c("condition", "replicate", "concentration")
+    if((length(fl) > 1 ) || !is.na(data.fl))    
+      colnames(fl.mat) <- rep("", ncol(dat.mat))
+      colnames(fl.mat)[1:3] <- c("condition", "replicate", "concentration")
     # if((length(fl2) > 1 ) || !is.na(data.fl2))    colnames(fl2.mat)[1:3] <- c("condition", "replicate", "concentration")
-    if(((length(fl) > 1 ) || !is.na(data.fl)) && length(dat)>1)  colnames(fl.norm.mat)[1:3] <- c("condition", "replicate", "concentration")
+    if(((length(fl) > 1 ) || !is.na(data.fl)) && length(dat)>1)  
+      colnames(fl.norm.mat) <- rep("", ncol(dat.mat))
+      colnames(fl.norm.mat)[1:3] <- c("condition", "replicate", "concentration")
     # if(((length(fl2) > 1 ) || !is.na(data.fl2)) && length(dat)>1)  colnames(fl2.norm.mat)[1:3] <- c("condition", "replicate", "concentration")
 
     if(length(dat) > 1) {

--- a/R/growth_workflows.R
+++ b/R/growth_workflows.R
@@ -299,12 +299,19 @@ growth.workflow <- function(
     if (export.res)
       dir.create(wd, showWarnings = FALSE)
 
+    if(nrow(grofit1[["gcFit"]][["gcTable"]]) == 1){
+      gcTable <- as.data.frame((grofit1[["gcFit"]][["gcTable"]]))
+      gcTable <- data.frame(lapply(gcTable, as.character))
+    } else {      
     gcTable <- data.frame(
       apply(
         grofit[["gcFit"]][["gcTable"]], 2,
         as.character
       )
     )
+        }
+
+      
     res.table.gc <- cbind(
       gcTable[, 1:3], Filter(
         function(x) !all(is.na(x)),


### PR DESCRIPTION
A few commands in tidy_to_custom and read_data throw errors for tidyformat data. I adjusted the code here and there to accommodate (my) tidy format data. I do not see a problem with slightly different data (where blanks do carry different rep numbers, or no rep numbers). 